### PR TITLE
changed to download metadata tsv

### DIFF
--- a/src/components/CorpusMetadata/NavigationAndStats/DownloadData.js
+++ b/src/components/CorpusMetadata/NavigationAndStats/DownloadData.js
@@ -41,8 +41,8 @@ const DownloadData = ({ data, status }) => {
     <Tooltip
       title={
         checkedBooks.length > 0
-          ? "Download selected metadata in csv format"
-          : "Download metadata on this page in csv format"
+          ? "Download selected metadata in tsv format"
+          : "Download metadata on this page in tsv format"
       }
       placement="top"
     >
@@ -55,7 +55,9 @@ const DownloadData = ({ data, status }) => {
           specificData.length !== 0 && (
             <CSVLink
               data={specificData}
-              filename="kitabapps_data.csv"
+              enclosingCharacter={''}
+              separator={"\t"}
+              filename="kitabapps_data.tsv"
               style={{
                 textDecoration: "none",
                 display: "flex",


### PR DESCRIPTION
Changed the metadata download function to create a tsv rather than a csv file (ensuring that the fields are not wrapped in quotation marks).

Test site: https://mabarber92.github.io/explore/
