### PR TITLE
Bug fix #43 - Handling URL errors

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -171,6 +171,7 @@ function App() {
   const [selectedLine, setSelectedLine] = useState({});
   const [showWikiEdDiff, setWikiEdDiff] = useState(false);
   const [isError, setIsError] = useState(false);
+  const [errorType, setErrorType] =  useState("We may not have text reuse data for these texts, or there might be another problem. Error Type: Unknown")
   const [showOptions, setShowOptions] = useState(false);
   const [showDownloadOptions, setShowDownloadOptions] = useState(false);
   const [includeURL, setIncludeURL] = useState(true);
@@ -355,6 +356,8 @@ function App() {
         setFocusedDataIndex,
         isError,
         setIsError,
+        errorType,
+        setErrorType,
         showOptions,
         setShowOptions,
         showDownloadOptions, 

--- a/src/App.js
+++ b/src/App.js
@@ -171,7 +171,7 @@ function App() {
   const [selectedLine, setSelectedLine] = useState({});
   const [showWikiEdDiff, setWikiEdDiff] = useState(false);
   const [isError, setIsError] = useState(false);
-  const [errorType, setErrorType] =  useState("We may not have text reuse data for these texts, or there might be another problem. Error Type: Unknown")
+  const [errorType, setErrorType] =  useState(["We may not have text reuse data for these texts, or there might be another problem.", "Error Type: Unknown"])
   const [showOptions, setShowOptions] = useState(false);
   const [showDownloadOptions, setShowDownloadOptions] = useState(false);
   const [includeURL, setIncludeURL] = useState(true);

--- a/src/components/Visualisation/index.jsx
+++ b/src/components/Visualisation/index.jsx
@@ -282,7 +282,7 @@ const VisualisationPage = () => {
     if (failedBooks.length > 0) {
       setDataLoading({ ...dataLoading, uploading: false });
       setIsError(true);
-      setErrorType('The book ids in your URL do not match any books in the KITAB corpus. Please check your URL and try again. Failed ids: ' + failedBooks.join(", "));
+      setErrorType('Some book Ids in your pairwise URL do not match books in the KITAB corpus. Please check your URL and try again. Failed Ids: ' + failedBooks.join(", "));
       setIsLoading(false);
 
     } else if (book_names.length === 1 || book_names[1] === "all") {

--- a/src/components/Visualisation/index.jsx
+++ b/src/components/Visualisation/index.jsx
@@ -282,7 +282,7 @@ const VisualisationPage = () => {
     if (failedBooks.length > 0) {
       setDataLoading({ ...dataLoading, uploading: false });
       setIsError(true);
-      setErrorType('Some book Ids in your pairwise URL do not match books in the KITAB corpus. Please check your URL and try again. Failed Ids: ' + failedBooks.join(", "));
+      setErrorType(["Some book Ids in your pairwise URL do not match books in the KITAB corpus. Please check your URL and try again.", "Failed Ids: " + failedBooks.join(", ")]);
       setIsLoading(false);
 
     } else if (book_names.length === 1 || book_names[1] === "all") {
@@ -322,7 +322,7 @@ const VisualisationPage = () => {
       } catch (err) {
         setDataLoading({ ...dataLoading, uploading: false });
         setIsError(true);
-        setErrorType('There was an error loading the data for the book: ' + book_names[0] + '. Please check your URL and try again.');
+        setErrorType(["There was an error loading the data for the book: " + book_names[0] + ".", "Please check your URL and try again."]);
         setIsLoading(false);
       }
     } else if (book_names.length === 2) {
@@ -366,7 +366,7 @@ const VisualisationPage = () => {
           // If the pairwise URL is not found then set error state
           setDataLoading({ ...dataLoading, uploading: false });
           setIsError(true);
-          setErrorType('The pairwise text reuse data for the book ids: ' + book_names.join(", ") + ' could not be found. There may not be text reuse data for this pair.');
+          setErrorType(["The pairwise text reuse data for the book ids: " + book_names.join(", ") + " could not be found.", "There may not be text reuse data for this pair."]);
           setIsLoading(false);
         } 
 
@@ -413,7 +413,7 @@ const VisualisationPage = () => {
     } else {
       setDataLoading({ ...dataLoading, uploading: false });
       setIsError(true);
-      setErrorType('You have not supplied a valid URL.')
+      setErrorType(['You have not supplied a valid URL.', ''])
       setIsLoading(false);
     }
   };
@@ -456,11 +456,11 @@ const VisualisationPage = () => {
         >
           <Typography variant="h4">No data found to visualize.</Typography>
           <Typography variant="body1" color="grey">
-            {errorType}
+            {errorType[0]}
           </Typography>
-          {/* <Typography variant="body1" color="grey">
-            [Please make sure the file name is correct]
-          </Typography> */}
+          <Typography variant="body1" color="grey">
+            {errorType[1]}
+          </Typography>
         </Box>
       ) : (
         <Box position="relative">

--- a/src/components/Visualisation/index.jsx
+++ b/src/components/Visualisation/index.jsx
@@ -17,6 +17,9 @@ import { downloadCsvData, getOneBookReuseStats, getOneBookMsData } from "../../s
 import { Context } from "../../App";
 import { checkPairwiseCsvResponse } from "../../utility/Helper";
 
+
+
+
 // Check the metadata response from a URL - return an array of failed books
 const checkVersionMeta = (versionMeta, bookNames) => {
   const failedBooks = [];
@@ -133,6 +136,8 @@ const VisualisationPage = () => {
     setIsFileUploaded,
     isError,
     setIsError,
+    errorType,
+    setErrorType,
     setUrl,
     defaultReleaseCode,
     setMainVersionCode,
@@ -277,6 +282,7 @@ const VisualisationPage = () => {
     if (failedBooks.length > 0) {
       setDataLoading({ ...dataLoading, uploading: false });
       setIsError(true);
+      setErrorType('The book ids in your URL do not match any books in the KITAB corpus. Please check your URL and try again. Failed ids: ' + failedBooks.join(", "));
       setIsLoading(false);
 
     } else if (book_names.length === 1 || book_names[1] === "all") {
@@ -316,6 +322,7 @@ const VisualisationPage = () => {
       } catch (err) {
         setDataLoading({ ...dataLoading, uploading: false });
         setIsError(true);
+        setErrorType('There was an error loading the data for the book: ' + book_names[0] + '. Please check your URL and try again.');
         setIsLoading(false);
       }
     } else if (book_names.length === 2) {
@@ -359,6 +366,7 @@ const VisualisationPage = () => {
           // If the pairwise URL is not found then set error state
           setDataLoading({ ...dataLoading, uploading: false });
           setIsError(true);
+          setErrorType('The pairwise text reuse data for the book ids: ' + book_names.join(", ") + ' could not be found. There may not be text reuse data for this pair.');
           setIsLoading(false);
         } 
 
@@ -405,6 +413,7 @@ const VisualisationPage = () => {
     } else {
       setDataLoading({ ...dataLoading, uploading: false });
       setIsError(true);
+      setErrorType('You have not supplied a valid URL.')
       setIsLoading(false);
     }
   };
@@ -447,12 +456,11 @@ const VisualisationPage = () => {
         >
           <Typography variant="h4">No data found to visualize.</Typography>
           <Typography variant="body1" color="grey">
-            We may not have text reuse data for these texts, or there might be
-            another problem.
+            {errorType}
           </Typography>
-          <Typography variant="body1" color="grey">
+          {/* <Typography variant="body1" color="grey">
             [Please make sure the file name is correct]
-          </Typography>
+          </Typography> */}
         </Box>
       ) : (
         <Box position="relative">

--- a/src/utility/Helper.js
+++ b/src/utility/Helper.js
@@ -468,5 +468,5 @@ export {
   buildPairwiseCsvURL,
   loadChartFromUrl,
   checkPairwiseCsvResponse,
-  
+  enableMockFetch
 };

--- a/src/utility/Helper.js
+++ b/src/utility/Helper.js
@@ -4,6 +4,33 @@ const { GITHUB_BASE_URL, GITHUB_BASE_RAW_URL } = config;
 
 
 /**
+ * Testing functionality to make a server fetch fail
+ * To use - call enableMockFetch({ failForMatch: srtFolders[releaseCode] }) to fail for a specific release code
+ */
+let originalFetch = null;
+
+function enableMockFetch({ failForMatch = "" } = {}) {
+  if (originalFetch) return; // already mocked
+
+  originalFetch = global.fetch;
+
+  global.fetch = async (url, options) => {
+    if (failForMatch && url.includes(failForMatch)) {
+      console.warn(`[MockFetch] Forcing failure for: ${url}`);
+      throw new Error("Simulated fetch failure");
+    }
+
+    // fallback behavior: all URLs fail
+    if (!failForMatch) {
+      console.warn(`[MockFetch] Forcing global failure: ${url}`);
+      throw new Error("Simulated fetch failure");
+    }
+
+    return originalFetch(url, options); // fallback to real fetch
+  };
+}
+
+/**
  * Help to try catch to ensure we return false in all cases of invalid urls
  * @param {String} url The URL to check
  * @returns {Boolean} True if the URL is valid, false otherwise


### PR DESCRIPTION
# Describe your changes:
* Created a function for checking URLs - checkPairwiseCsvResponse - that uses a logic to check first the full pairwise (or light depending on usage) following by GitHub URL if the server does not respond. Returns the working URLs or null (if URL does not respond)
* Updated buildPairwiseCsvURL to allow the creation of Github URLs - change of logic means that it works as before, just added an additional argument with default parameter so that it does not break existing processes
* Added enableMockFetch function to helper - add this into code to deliberately break a fetch from the KITAB server (forcing a fallback to GitHub) - this can be used to check that GitHub fallbacks work as expected
* refactored src/components/CorpusMetadata/NavigationAndStats/index.js to make use of the new checkPairwiseCsvResponse function
* Refactored src/components/Visualisation/index.jsx so that it uses the checkPairwiseCsvResponse to check the pairwise URLs before loading them into the viz (older approach commented out - consider deleting after review to clean up code)
* Fixed bug where a faulty URL would cause the app to error (described in #43). Issue was caused when a URL partially produced results in a request to the API (e.g. one of the book ids had a typo). This has been addressed by a function checkVersionMeta that checks if any of the API responses in the returned array contain errors. If an error is found, then the function returns the erronous parts of the ID, and displays the error message. **We should consider if the functions that send requests to the API should check the return for errors before returning them - this might be a little more consistent, rather than dealing with this in every place it happens**
* While addressing this error I've added a new errorType variable which we can use to store an error message based on the kind of error that occurs. Now if you add a faulty URL, it will tell you the parts of the URL that caused the error in the error message.

# This pull requests adresses/closes the following issues: 
Closes #43

# Changes are staged [here](https://mabarber92.github.io/explore/#/2023.1.8/?version=pri)


# I have checked:
(add x between the brackets to check the box; add checkboxes for checks relevant to your changes):
* [X] metadata search still works
* [X] opening pairwise viz from selection of two texts still works
* [X] opening pairwise viz from text reuse pane still works
* [X] opening diff from pairwise viz still works
* [X] opening one-to-many viz from metadata page still works
* [X] opening diff from one-to-many viz still works
* [X] opening pairwise viz from one-to-many still works
* [X] selecting a pair of texts in the metadata without text reuse between them shows a message saying no reuse at top of metadata page
* [X] a URL with invalid ids produces an invalid ids error message
* [X] a URL with valid ids, but for which we lack text reuse data returns a message stating no text reuse data available


# Reviewer: @pverkind 

# Reviewer should check: 
* [ ] opening pairwise viz from selection of two texts still works
* [ ] opening pairwise viz from text reuse pane still works
* [ ] opening diff from pairwise viz still works
* [ ] opening one-to-many viz from metadata page still works
* [ ] opening diff from one-to-many viz still works
* [ ] opening pairwise viz from one-to-many still works
* [ ] selecting a pair of texts in the metadata without text reuse between them shows a message saying no reuse at top of metadata page
* [ ] a URL with invalid ids produces an invalid ids error message
* [ ] a URL with valid ids, but for which we lack text reuse data returns a message stating no text reuse data available
