### PR TITLE
Drawer pairwise #47 - adding lite download and GitHub fallback

### DIFF
--- a/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TableHeader.js
+++ b/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TableHeader.js
@@ -22,7 +22,7 @@ const TableHeader = ({ sortingOrder, setSortingOrder }) => {
       <Box
         display={"flex"}
         alignItems={"center"}
-        width={"80%"}
+        width={"70%"}
         padding={"0px 15px"}
       >
         Work
@@ -49,7 +49,7 @@ const TableHeader = ({ sortingOrder, setSortingOrder }) => {
           setSortingOrder={setSortingOrder}
         />
       </Box>
-      <Typography width={"10%"} padding={"0px 15px"}></Typography>
+      <Typography width={"20%"} padding={"0px 15px"}></Typography>
     </Box>
   );
 };

--- a/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TextReuseTable.js
+++ b/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TextReuseTable.js
@@ -3,13 +3,9 @@ import { Box, CircularProgress, IconButton, Tooltip, Typography } from "@mui/mat
 import TableHeader from "./TableHeader";
 import { getVersionMetadataById } from "../../../../../services/CorpusMetaData";
 import {  getOneBookReuseStats } from "../../../../../services/TextReuseData";
-import { buildPairwiseCsvURL, checkPairwiseCsvResponse, enableMockFetch } from "../../../../../utility/Helper";
+import { buildPairwiseCsvURL, checkPairwiseCsvResponse } from "../../../../../utility/Helper";
 import { Context } from "../../../../../App";
 import Papa from "papaparse";
-import { 
-  // lightSrtFolders, 
-  // srtFoldersGitHub, 
-  srtFolders } from "../../../../../assets/srtFolders";
 
 const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1MetadataLoading }) => { 
   const { isOpenDrawer, setIsOpenDrawer } = useContext(Context);
@@ -29,10 +25,8 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
     // Prevent from running at closing of the drawer
     if (!isOpenDrawer) return;
     // If we have book1 - check what kind of data can be fetched (is the server live or are we defaulting to GitHub?)
-    if (b1Metadata && b1Metadata.version_uri) {
-      
+    if (b1Metadata && b1Metadata.version_uri) {      
       const releaseCode = JSON.parse(localStorage.getItem("release_code"));
-      enableMockFetch({ failForMatch: srtFolders[releaseCode] }); 
       const checkServerResponse = async (book1) => {
         const csvObj = await checkPairwiseCsvResponse(releaseCode, book1);
         if (csvObj.githubUrl) {
@@ -298,6 +292,7 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
                     display={"flex"}
                     alignItems={"center"}
                   >
+                    { useGithubUrl || liteDataExists ? (
                     <Tooltip placement="top" title={"Visualization"}>
                       <Typography>
                         <button
@@ -319,7 +314,9 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
                         </button>
                       </Typography>
                     </Tooltip>
-
+                    ) : null
+                    }
+                    { fullDataExists ? (
                     <Tooltip placement="top" title={"Download CSV"}>
                       <Typography>
                         <IconButton
@@ -337,7 +334,9 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
 
                       </Typography>
                     </Tooltip>
-
+                    ) : null
+                    }
+                    { useGithubUrl || liteDataExists ? (
                     <Tooltip placement="top" title={"Download Lite CSV"}>
                       <Typography>
                         <IconButton
@@ -355,6 +354,8 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
 
                       </Typography>
                     </Tooltip>
+                    ) : null
+                  }
                   </Box>
                 </Box>
               )

--- a/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TextReuseTable.js
+++ b/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TextReuseTable.js
@@ -132,13 +132,13 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
    * @param {Object} b1Metadata full metadata of book1
    * @param {Object} book2ID version ID of book2
    */
-  const downloadPairwiseCsv = async (b1Metadata, book2ID) => {
+  const downloadPairwiseCsv = async (b1Metadata, book2ID, light=false, github=false) => {
     // we already have full metadata of book1;
     // download the metadata for book 2 and get the ID:
     const releaseCode = JSON.parse(localStorage.getItem("release_code"));
     const b2Metadata = await getVersionMetadataById(releaseCode, book2ID);
     // build the URL to the CSV file:
-    const csvUrl = await buildPairwiseCsvURL(releaseCode, b1Metadata, b2Metadata);
+    const csvUrl = await buildPairwiseCsvURL(releaseCode, b1Metadata, b2Metadata, light, github);
     const csvFilename = csvUrl.split("/").pop();
     // create a temporary link to the csv file to trigger the download:
     const link = document.createElement('a');
@@ -218,7 +218,7 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
                   }}
                 >
                   <Typography
-                    width={"80%"}
+                    width={"70%"}
                     padding={"0px 15px"}
                     sx={{
                       wordWrap: "break-word",
@@ -242,7 +242,7 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
                     {item?.alignments}
                   </Typography>
                   <Box
-                    width={"10%"}
+                    width={"20%"}
                     padding={"0px 15px"}
                     display={"flex"}
                     alignItems={"center"}
@@ -282,6 +282,24 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
                           onClick={() => downloadPairwiseCsv(b1Metadata, item.id)}
                         >
                           <i className="fa-solid fa-file"></i>
+                        </IconButton>
+
+                      </Typography>
+                    </Tooltip>
+
+                    <Tooltip placement="top" title={"Download Lite CSV"}>
+                      <Typography>
+                        <IconButton
+                          sx={{
+                            background: "none",
+                            border: "0px",
+                            cursor: "pointer",
+                            fontSize: "18px",
+                            color: "#7593af",
+                          }}
+                          onClick={() => downloadPairwiseCsv(b1Metadata, item.id, true)}
+                        >
+                          <i className="fa-solid fa-file-half-dashed"></i>
                         </IconButton>
 
                       </Typography>

--- a/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TextReuseTable.js
+++ b/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TextReuseTable.js
@@ -317,7 +317,7 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
                     ) : null
                     }
                     { fullDataExists ? (
-                    <Tooltip placement="top" title={"Download CSV"}>
+                    <Tooltip placement="top" title={"Download CSV (with text of alignments)"}>
                       <Typography>
                         <IconButton
                           sx={{
@@ -337,7 +337,7 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
                     ) : null
                     }
                     { useGithubUrl || liteDataExists ? (
-                    <Tooltip placement="top" title={"Download Lite CSV"}>
+                    <Tooltip placement="top" title={"Download Lite CSV (excluding text of alignments)"}>
                       <Typography>
                         <IconButton
                           sx={{

--- a/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TextReuseTable.js
+++ b/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TextReuseTable.js
@@ -174,14 +174,31 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
     // build the URL to the CSV file:
     const csvUrl = await buildPairwiseCsvURL(releaseCode, b1Metadata, b2Metadata, light, github);
     const csvFilename = csvUrl.split("/").pop();
-    // create a temporary link to the csv file to trigger the download:
-    const link = document.createElement('a');
-    link.href = csvUrl;
-    link.setAttribute('download', csvFilename); 
-    document.body.appendChild(link);
-    // download and clean up:
-    link.click();
-    document.body.removeChild(link);
+    if (github) {
+        // If the URL is a GitHub URL, then we need to download it differently
+        const response = await fetch(csvUrl);
+        if (!response.ok) {
+          throw new Error("Network response was not ok");
+        }
+        const blob = await response.blob();
+        const url = window.URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.setAttribute("download", csvFilename); // Set the file name for download
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+       }
+    else {
+      // create a temporary link to the csv file to trigger the download:
+      const link = document.createElement('a');
+      link.href = csvUrl;
+      link.setAttribute('download', csvFilename); 
+      document.body.appendChild(link);
+      // download and clean up:
+      link.click();
+      document.body.removeChild(link);
+    }
   }
 
   /**
@@ -331,7 +348,7 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
                             fontSize: "18px",
                             color: "#7593af",
                           }}
-                          onClick={() => downloadPairwiseCsv(b1Metadata, item.id, true)}
+                          onClick={() => downloadPairwiseCsv(b1Metadata, item.id, true, useGithubUrl)}
                         >
                           <i className="fa-solid fa-file-half-dashed"></i>
                         </IconButton>

--- a/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TextReuseTable.js
+++ b/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TextReuseTable.js
@@ -281,7 +281,7 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
                           }}
                           onClick={() => downloadPairwiseCsv(b1Metadata, item.id)}
                         >
-                          <i className="fa-solid fa-file-csv"></i>
+                          <i className="fa-solid fa-file"></i>
                         </IconButton>
 
                       </Typography>

--- a/src/components/CorpusMetadata/NavigationAndStats/index.js
+++ b/src/components/CorpusMetadata/NavigationAndStats/index.js
@@ -85,6 +85,8 @@ const NavigationAndStats = () => {
     if (!booksReady) return;
     const checkSelectedUrls = async () => {
 
+      
+
       if (checkedBooks.length !== 2) {
         // If we have not selected two books, then set these pairwise parameters to null
         setPairwiseLiteUrl(null);
@@ -95,7 +97,7 @@ const NavigationAndStats = () => {
         }
       else {
         console.log("Checking selected books for pairwise text reuse data");
-        
+
         // Activate the loading function - allows us to show a loading spinner after a delay (to avoid flickering)
         setLoadingReuseData(true);
         
@@ -119,6 +121,7 @@ const NavigationAndStats = () => {
         setPairwiseUrl(urlObj.pairwiseUrl);
         setPairwiseLiteUrl(urlObj.pairwiseLiteUrl);
         setGithubUrl(urlObj.githubUrl);
+
 
         // // Create URLs for the selected books - if URL returns a response, then we set the variable
         // const LiteUrl = await buildPairwiseCsvURL(releaseCode, book1, book2, true);


### PR DESCRIPTION
# Describe your changes:
These changes brings the pairwise csv download functionality in the text reuse drawer into alignment with what happens when you select a pair of books in the metadata table. Changes as follows:
* updated the icon to be the same as with the selection mode
* added the download for lite files (updated downloadPairwiseCsv to deal with lite files)
* updated helper in checkPairwiseCsvResponse to check a server response for a parent folder containing csv files. If only one book is given, it defaults to this use case and checks for the reuse folder. If the folder does not return a response, then it returns Github (it does not check GitHub as it is not possible to check the folder response in GitHub - only for specific csv files).
* The updated checkPairwiseCsvResponse is now invoked in TextReuseTable.js to check if the server links exist and return variables with boolean values
* Those boolean values are then used to:
   * remove the icon for the full reuse data if the data does not exist (that is, if the server is unavailable)
   * change the link for the lite file to the GitHub URL if the server is unavailable
   * remove the icons if no data is available (right now this state is not possible, as it defaults to GitHub if the server does not return a response, but we could in future find a better logic for checking if the GitHub folder exists and use that to hide icons if no data is currently available)
* All functionality has been tested using enableMockFetch (to ensure the GitHub fallback works as expected) 

# This pull requests adresses/closes the following issues: 
Closes #47

# Changes are staged [here](https://mabarber92.github.io/explore/#/2023.1.8/?version=pri&search=kulayni)


# I have checked:
(add x between the brackets to check the box; add checkboxes for checks relevant to your changes):
* [x] metadata search still works
* [x] opening pairwise viz from selection of two texts still works
* [x] opening pairwise viz from text reuse pane still works
* [x] opening diff from pairwise viz still works
* [x] opening one-to-many viz from metadata page still works
* [x] opening diff from one-to-many viz still works
* [x] the normal book selection functionality works as expected (a pair of books with reuse data returns links, a pair of books without reuse data returns no text reuse data available) - imp. as I have modified the underlying function
* [x] in the drawer three icons appear and point to the correct data- pointing to: pairwise visualisation, full pairwise data, light pairwise data
* [x] GitHub fallbacks work as expected (checked locally, owing to the need to modify the code to initiate a test)

# Reviewer: @pverkind 

# Reviewer should check: 
* [x] metadata search still works
* [x] opening pairwise viz from selection of two texts still works
* [x] opening pairwise viz from text reuse pane still works
* [x] opening diff from pairwise viz still works
* [x] opening one-to-many viz from metadata page still works
* [x] opening diff from one-to-many viz still works
* [x] the normal book selection functionality works as expected (a pair of books with reuse data returns links, a pair of books without reuse data returns no text reuse data available) - imp. as I have modified the underlying function
* [x] in the drawer three icons appear and point to the correct data- pointing to: pairwise visualisation, full pairwise data, light pairwise data

