### PR TITLE
Svg download

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,6 @@ import { createContext, useRef, useState } from "react";
 import { HashRouter as Router, Routes, Route } from "react-router-dom";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { green, red } from "@mui/material/colors";
-import * as saveSvgAsPng from "save-svg-as-png";
 
 import "./App.css";
 import Insight from "./pages/Insight";
@@ -241,51 +240,6 @@ function App() {
     setIsOpenDrawer(true);
   };
 
-  const downloadPNG = (downloadFileName, svgId) => {
-    //const downloadFileName = `${metaData?.book1?.versionCode}_${metaData?.book2?.versionCode}.png`;
-    const svg = document.getElementById(svgId);
-    const newSvg = svg.cloneNode(true);
-
-    let scale = 3; // default scale: 300 % 
-
-    if (outputImageWidth) {  // context variable!
-      const inchPerMM = 1 / 25.4;
-      const svgPixelWidth = svg.clientWidth;
-      const outputWidthInInches = outputImageWidth * inchPerMM;
-      const targetPixelWidth = outputWidthInInches * (dpi || 300); // dpi is also a context variable; use 300 if dpi is undefined
-      scale = targetPixelWidth / svgPixelWidth / window.devicePixelRatio;
-      console.log("window.devicePixelRatio: "+window.devicePixelRatio)
-
-      /*
-       NB: the save-svg-as-png library gets the width of the svg in one of these ways:
-       * - svg.viewBox.baseVal["width"] : returns 0 in our case
-       * - newSvg.getAttribute("width") : returns same value as svg.clientWidth
-       * - svg.getBoundingClientRect()["width"] : returns same value as svg.clientWidth
-       * - window.getComputedStyle(svg).getPropertyValue("width") : returns same value as svg.clientWidth
-      
-      console.log('svg.viewBox.baseVal["width"]: '+svg.viewBox.baseVal["width"]);
-      console.log('newSvg.getAttribute("width"): '+newSvg.getAttribute("width"));
-      console.log('svg.getBoundingClientRect()["width"]: '+svg.getBoundingClientRect()["width"]);
-      console.log('window.getComputedStyle(svg).getPropertyValue("width") '+window.getComputedStyle(svg).getPropertyValue("width"));
-      
-      
-      console.log(`requested image width: ${outputImageWidth} mm`);
-      console.log(`requested dpi: ${dpi}`);
-      console.log(`svg width: ${svgPixelWidth}`);
-      console.log(`svg bounding box width: ${svg.getBBox().width}`);
-      console.log(`Output width: ${outputWidthInInches} inch`);
-      console.log(`Output width: ${targetPixelWidth} pixels`);
-      console.log(`Scale: ${scale}`);
-      */
-    }
-
-    // save the png:
-    saveSvgAsPng.saveSvgAsPng(newSvg, downloadFileName, {
-      scale: scale, 
-      backgroundColor: "white",
-    });
-  };
-
   return (
     <Context.Provider
       value={{
@@ -435,7 +389,6 @@ function App() {
         setRemoveTags,
         selfReuseOnly,
         setSelfReuseOnly,
-        downloadPNG,
         advanceSearch,
         setAdvanceSearch,
       }}

--- a/src/components/Visualisation/SectionHeader/VisualizationHeader/DownloadPanel.js
+++ b/src/components/Visualisation/SectionHeader/VisualizationHeader/DownloadPanel.js
@@ -3,15 +3,17 @@ import { Box, Button, Typography, Tooltip } from "@mui/material";
 import * as d3 from "d3";
 import IncludeMetaDropdown from "./IncludeMetaDropdown";
 import OutputDimensions from "./OutputDimensions";
+import { downloadPNG, downloadSVG } from "../../../../utility/Helper";
 import { Context } from "../../../../App";
 
 
 const DownloadPanel = ( {isPairwiseViz, downloadFileName} ) => {
   const { 
-    downloadPNG, 
     tickFontSize, 
     includeURL,
-    setIncludeURL
+    setIncludeURL,
+    outputImageWidth,
+    dpi
   } = useContext(Context);
   
   const svgSelector = isPairwiseViz ? 'svgChart' : 'scatterChart';
@@ -72,7 +74,7 @@ const DownloadPanel = ( {isPairwiseViz, downloadFileName} ) => {
           </Button>
         </Tooltip>
         <Button
-          onClick={() => downloadPNG(downloadFileName, svgSelector, includeURL)}
+          onClick={() => downloadPNG(svgSelector, downloadFileName, outputImageWidth, dpi)}
           color="primary"
           variant="outlined"
           rel="noreferrer"
@@ -80,6 +82,16 @@ const DownloadPanel = ( {isPairwiseViz, downloadFileName} ) => {
           style={{textTransform: 'none'}}
         >
           Download PNG
+        </Button>
+        <Button
+          onClick={() => downloadSVG(svgSelector, downloadFileName)}
+          color="primary"
+          variant="outlined"
+          rel="noreferrer"
+          target="_blank"
+          style={{textTransform: 'none'}}
+        >
+          Download SVG
         </Button>
       </Box>
     </>

--- a/src/components/Visualisation/SectionHeader/VisualizationHeader/index.js
+++ b/src/components/Visualisation/SectionHeader/VisualizationHeader/index.js
@@ -85,7 +85,7 @@ const VisualizationHeader = ({ restoreCanvas, isPairwiseViz, colorScale, width }
                 mr: "10px",
               }}
             >
-              <i className="fa-solid fa-cloud-arrow-down"></i>
+              <i className={showDownloadOptions ? "fa-solid fa-chevron-up" : "fa-solid fa-cloud-arrow-down"}></i>
             </Button>
           </Tooltip>
         </Box>


### PR DESCRIPTION
# Describe your changes:
* Added a button to download the visualisations as svg
* moved the downloadPNG function (and the new downloadSVG function) to utility/Helper.js
* replace the download icon with a chevron up icon when the download options are displayed

# This pull requests adresses/closes the following issues: 
closes #61  

# Changes are staged [here](https://pverkind.github.io/explore/#/2023.1.8/?version=pri)
(your GitHub Pages site or https://witty-bay-0dafe9a10.4.azurestaticapps.net/)

# I have checked:
(add x between the brackets to check the box; add checkboxes for checks relevant to your changes):
* [x] metadata search still works
* [x] opening pairwise viz from selection of two texts still works
* [x] opening pairwise viz from text reuse pane still works
* [x] opening diff from pairwise viz still works
* [x] opening one-to-many viz from metadata page still works
* [x] opening diff from one-to-many viz still works
* [x] download PNG button in pairwise viz still works
* [x] download PNG button in one-to-many viz still works
* [x] download SVG button in pairwise viz works
* [x] download SVG button in  one-to-many viz works

# Reviewer: @mabarber92 

# Reviewer should check: 
* [ ] download PNG button in pairwise viz still works
* [ ] download PNG button in one-to-many viz still works
* [ ] download SVG button in pairwise viz works
* [ ] download SVG button in  one-to-many viz works
