### PR TITLE
Display fixes - drawer and advanced search

### DIFF
--- a/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TextReuseTable.js
+++ b/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TextReuseTable.js
@@ -96,7 +96,6 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
             book_lc: rest.book.toLowerCase()
           }));
           setStatsData(stats);
-          console.log("Stats data loaded: ");
         }
       });
     };

--- a/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TextReuseTable.js
+++ b/src/components/CorpusMetadata/Drawer/TextReuse/TextReuseData/TextReuseTable.js
@@ -96,6 +96,7 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
             book_lc: rest.book.toLowerCase()
           }));
           setStatsData(stats);
+          console.log("Stats data loaded: ");
         }
       });
     };
@@ -103,7 +104,10 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
     // fetch the text reuse stats data:
     try {
       fetchData(b1Metadata);
-      setIsLoading(false);
+      console.log("Stopping spinner")
+      if (statsData.length > 0) {
+        setIsLoading(false);
+      }
       setIsError(false);
     } catch {
       if (isMounted) {
@@ -113,7 +117,7 @@ const TextReuseTable = ({ b1Metadata, normalizedQuery, handleRedirectToChart, b1
         setTotal(0);
       }
     }
-  }, [b1Metadata, isOpenDrawer]);
+  }, [b1Metadata, isOpenDrawer, statsData]);
 
   // filter the data whenever the search query changes:
   // NB: the query has already been lowercased and trimmed!

--- a/src/components/CorpusMetadata/SearchFilter/AdvanceSearch/index.js
+++ b/src/components/CorpusMetadata/SearchFilter/AdvanceSearch/index.js
@@ -61,6 +61,7 @@ export default function AdvanceSearch() {
       max_tok_count: tempAdvanceSearch?.max_tok_count,
       min_tok_count: tempAdvanceSearch?.min_tok_count,
       editor: tempAdvanceSearch?.editor,
+      edition_place: tempAdvanceSearch?.edition_place,
       publisher: tempAdvanceSearch?.publisher,
       edition_date: tempAdvanceSearch?.edition_date,
       died_before_AH: tempAdvanceSearch?.died_before_AH,

--- a/src/components/CorpusMetadata/SearchFilter/SetSearchField.js
+++ b/src/components/CorpusMetadata/SearchFilter/SetSearchField.js
@@ -22,7 +22,7 @@ export default function SetSearchField() {
     normalizedSearch,
     setNormalizedSearch,
     advanceSearchModal,
-    setAdvanceSearchModal,
+    setAdvanceSearchModal
   } = useContext(Context);
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -69,6 +69,8 @@ export default function SetSearchField() {
       );
     }
   }, [searchParams, setNormalizedSearch]);
+
+  
 
   return (
     <Box

--- a/src/components/CorpusMetadata/SearchFilter/index.js
+++ b/src/components/CorpusMetadata/SearchFilter/index.js
@@ -121,11 +121,9 @@ const SearchFilters = ({ handleResetFilters, getQuery }) => {
     let newArr = [];
     for (let i = 0; i < arr.length; i++) {
       if (searchParams.has(arr[i]) && isExist(Object.keys(paramMappings)[i])) {
-        console.log("searchParams", searchParams.get(arr[i]));
         newArr = [...newArr, `${paramMappings[arr[i]]}: ${searchParams.get(arr[i])}`];
       }
     }
-    console.log("newArr", newArr);
     setAdvanceParams(newArr);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/CorpusMetadata/SearchFilter/index.js
+++ b/src/components/CorpusMetadata/SearchFilter/index.js
@@ -215,36 +215,7 @@ const SearchFilters = ({ handleResetFilters, getQuery }) => {
                   fullWidth={true}
                 />
               </form>
-              {advanceParams.length !== 0 && (
-                <Box
-                  sx={{
-                    width: "100%",
-                    height: "50px",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
-                  <Typography variant="body1">Advanced Search:</Typography>
-                  {advanceParams &&
-                    advanceParams.map((item, i) => (
-                      <Typography
-                        key={i}
-                        variant="body2"
-                        sx={{ ml: "4px", color: "#2863A5" }}
-                      >
-                        {item}
-                        {advanceParams.length === i + 1 ? "" : ", "}
-                      </Typography>
-                    ))}
-                  <Button
-                    sx={{ color: "red" }}
-                    onClick={clearAllAdvanceSearchFilter}
-                  >
-                    Clear All
-                  </Button>
-                </Box>
-              )}
+             
               {(searchParams.get("search") || text || searchField) && (
                 <Typography
                   sx={{
@@ -263,6 +234,36 @@ const SearchFilters = ({ handleResetFilters, getQuery }) => {
             </Box>
           </Grid>
         </Grid>
+        {advanceParams.length !== 0 && (
+              <Box
+                sx={{
+                  width: "100%",
+                  height: "50px",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <Typography variant="body1">Advanced Search:</Typography>
+                {advanceParams &&
+                  advanceParams.map((item, i) => (
+                    <Typography
+                      key={i}
+                      variant="body2"
+                      sx={{ ml: "4px", color: "#2863A5" }}
+                    >
+                      {item}
+                      {advanceParams.length === i + 1 ? "" : ", "}
+                    </Typography>
+                  ))}
+                <Button
+                  sx={{ color: "red" }}
+                  onClick={clearAllAdvanceSearchFilter}
+                >
+                  Clear All
+                </Button>
+              </Box>
+            )}
       </Grid>
     </Box>
   );

--- a/src/components/CorpusMetadata/SearchFilter/index.js
+++ b/src/components/CorpusMetadata/SearchFilter/index.js
@@ -121,9 +121,11 @@ const SearchFilters = ({ handleResetFilters, getQuery }) => {
     let newArr = [];
     for (let i = 0; i < arr.length; i++) {
       if (searchParams.has(arr[i]) && isExist(Object.keys(paramMappings)[i])) {
-        newArr = [...newArr, paramMappings[arr[i]]];
+        console.log("searchParams", searchParams.get(arr[i]));
+        newArr = [...newArr, `${paramMappings[arr[i]]}: ${searchParams.get(arr[i])}`];
       }
     }
+    console.log("newArr", newArr);
     setAdvanceParams(newArr);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
# Describe your changes:
These changes cover small display fixes to the UI in the drawer and advanced search
* Added an if statement to the drawer that checks if we have data to populate the table before stopping the loading spinner. Now when the spinner stops the table has loaded (no empty table).
* Fixed the grid so that the advanced search details box does not drag the x button outside of the search box above (there is still some unusual behaviour with the filter icons on small screens, but we should tackle this as part of #55 - as it all relates to the use of the grid in this and adjacent components)
* Updated the function in SearchFilter/index.js so that advanceParams contains the details of what is being queried by the advanced search (e.g. 'Died before: 300' , rather than just 'Died before'). I believe this was likely the intended functionality when this was originally designed.
* Addressed issue where the edition_place was missing from the advanced params (it was being used in the query, but not showing in the advanced filters list)

# This pull requests adresses/closes the following issues: 
closes #57 , closes #59

# Changes are staged [here](https://mabarber92.github.io/explore/)


# I have checked:
(add x between the brackets to check the box; add checkboxes for checks relevant to your changes):
* [x] metadata search still works
* [x] opening pairwise viz from selection of two texts still works
* [x] opening pairwise viz from text reuse pane still works
* [x] opening diff from pairwise viz still works
* [x] opening one-to-many viz from metadata page still works
* [x] opening diff from one-to-many viz still works
* [x] advanced search parameters all display when advanced search is used
* [x] loading spinner shows when the drawer is open and data is being loaded (when the spinner stops data has been loaded)

# Reviewer: @pverkind 

# Reviewer should check: 
* [x] advanced search parameters all display when advanced search is used
* [x] loading spinner shows when the drawer is open and data is being loaded (when the spinner stops data has been loaded)
