### PR TITLE
set up cookie consent and gtag tracking

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,17 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    
+    <!-- Add cookie consent css & js -->
+    <link rel="stylesheet"
+        type="text/css"
+        href="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.css"/>
+    <script src="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js"
+        data-cfasync="false"></script>
+
+    <!-- Add google analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TGJD7641K2"></script>
+
     <title>KITAB</title>
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -51,7 +51,7 @@
         data-cfasync="false"></script>
 
     <!-- Add google analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TGJD7641K2"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-184803711-1"></script>
 
     <title>KITAB</title>
   </head>

--- a/src/components/Common/Analytics/index.js
+++ b/src/components/Common/Analytics/index.js
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
-const GA_ID = "G-TGJD7641K2";
+const GA_ID = "UA-184803711-1";
 
 export default function Analytics() {
   const location = useLocation();

--- a/src/components/Common/Analytics/index.js
+++ b/src/components/Common/Analytics/index.js
@@ -1,0 +1,120 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const GA_ID = "G-TGJD7641K2";
+
+export default function Analytics() {
+  const location = useLocation();
+
+  // --------------------------
+  // Helpers
+  // --------------------------
+  function getCookie(name) {
+    const match = document.cookie.match(
+      "(^|[^;]+)\\s*" + name + "\\s*=\\s*([^;]+)"
+    );
+    return match ? match.pop() : "";
+  }
+
+  function ensureGtag() {
+    window.dataLayer = window.dataLayer || [];
+    window.gtag =
+      window.gtag ||
+      function gtag() {
+        window.dataLayer.push(arguments);
+      };
+  }
+
+  function enableAnalytics() {
+    ensureGtag();
+
+    // IMPORTANT: undo hard-disable (set by disableAnalytics)
+    window[`ga-disable-${GA_ID}`] = false;
+
+    // First-time init only
+    if (!window.__gaLoaded) {
+      window.gtag("js", new Date());
+      window.__gaLoaded = true;
+    }
+
+    // Always (re)apply config so re-enable works without refresh
+    window.gtag("config", GA_ID);
+
+    window.__gaEnabled = true;
+    console.log("Analytics enabled");
+  }
+
+  function disableAnalytics() {
+    // Immediately prevents GA from sending hits
+    window[`ga-disable-${GA_ID}`] = true;
+
+    window.__gaEnabled = false;
+    console.log("Analytics disabled");
+  }
+
+  // --------------------------
+  // 1️⃣ Initialisation + Consent
+  // --------------------------
+  useEffect(() => {
+    // Prevent double execution in dev StrictMode
+    if (window.__analyticsInitialized) return;
+    window.__analyticsInitialized = true;
+
+    function init() {
+      if (!window.cookieconsent) {
+        console.warn("cookieconsent not loaded");
+        return;
+      }
+
+      const consent = getCookie("cookieconsent_status");
+
+      // Start analytics if user consented or did not deny
+      if (consent === "allow" || consent === "") {
+        enableAnalytics();
+      } else {
+        disableAnalytics();
+      }
+
+      window.cookieconsent.initialise({
+        palette: {
+          popup: { background: "#efefef", text: "#404040" },
+          button: { background: "#2862a5", text: "#ffffff" },
+        },
+        type: "opt-out",
+        content: {
+          allow: "Approve",
+          dismiss: "Approve",
+          deny: "Reject",
+        },
+        onStatusChange: function () {
+          if (this.hasConsented()) enableAnalytics();
+          else disableAnalytics();
+        },
+        // Helps with the little “corner widget” revoke/restore interactions
+        onRevokeChoice: function () {
+          if (this.hasConsented()) enableAnalytics();
+          else disableAnalytics();
+        },
+      });
+    }
+
+    if (document.readyState === "complete") init();
+    else window.addEventListener("load", init);
+
+    return () => window.removeEventListener("load", init);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // --------------------------
+  // 2️⃣ Track Route Changes (SPA pageviews)
+  // --------------------------
+  useEffect(() => {
+    if (!window.__gaEnabled) return;
+
+    window.gtag("config", GA_ID, {
+      page_path: location.pathname + location.search,
+    });
+  }, [location]);
+
+  return null;
+}

--- a/src/components/Common/Layouts/index.js
+++ b/src/components/Common/Layouts/index.js
@@ -1,6 +1,7 @@
 import { Box, Grid } from "@mui/material";
 import NavigationBar from "../NavigationBar";
 import Footer from "../Footer";
+import Analytics from "../Analytics";
 
 const Layout = ({ children }) => {
   return (
@@ -16,6 +17,7 @@ const Layout = ({ children }) => {
           <Footer />
         </Grid>
       </Grid>
+      <Analytics />
     </Box>
   );
 };


### PR DESCRIPTION
This is a re-implentation of the KITAB website tracking for react. Refactored with significant help from ChatGPT.

Implementation (and changes) as follows:
- added dependencies (we're using a cookie consent package and css). These are imported alongside the google tracking script (with the gtag token) in public/index.html
- New script components/Common/Analytics/index.js does the work of delivering the cookie consent box and keeping track of whether the user has consented or not. If the user opens the cookie puck at the bottom, then it defaults to switching off consent until the user agrees again. This new script makes use of the react router so that we can keep track of pages (we may not want that level of granularity)
- ```<Analytics />``` is added to Common/Layouts/index.js after the footer

Expected behaviour: when the user clicks approve, a cookie indicates consent and tracking is activated. If they click disapprove then the cookie indicates there is no consent and the tracking is stopped. The choice is logged so we can check this. We log at the point when the function for enabling or disabling analytics is run, so the log should record what's actually happening with analytics. The popup should appear for anyone who hasn't recorded consent navigating to any of the pages for the first time. 

Test implementation is deployed here: https://mabarber92.github.io/explore/

I'm not sure if the analytics will feed through to google if it's not deployed on kitab-project.org , but it may be worth seeing if the site use is being recorded on the analytics side. If not, that test will need to wait until it's deployed fully (what matters for the moment is that the consent is working as it should)

